### PR TITLE
fix type traits and add some test cases

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -91,6 +91,7 @@ time compile_test array
 time compile_test_with_main doctest
 time compile_test_with_main color_on
 time compile_test_with_main color_off
+time compile_test_with_main type_traits
 
 time compile_doc_example minimal
 time compile_doc_example custom_print

--- a/scripts/compile_cl.bat
+++ b/scripts/compile_cl.bat
@@ -60,6 +60,6 @@ mkdir build
 %TIMEIT% cl.exe /O2 /D_CRT_SECURE_NO_WARNINGS /nologo /D_HAS_EXCEPTIONS=0 /EHsc /W4 /wd4611 /Isrc test/test_doctest.cpp /link /out:.\build\test_doctest.exe
 %TIMEIT% cl.exe /O2 /D_CRT_SECURE_NO_WARNINGS /nologo /D_HAS_EXCEPTIONS=0 /EHsc /W4 /wd4611 /Isrc test/test_color_off.cpp /link /out:.\build\test_color_off.exe
 %TIMEIT% cl.exe /O2 /D_CRT_SECURE_NO_WARNINGS /nologo /D_HAS_EXCEPTIONS=0 /EHsc /W4 /wd4611 /Isrc test/test_color_on.cpp /link /out:.\build\test_color_on.exe
+%TIMEIT% cl.exe /O2 /D_CRT_SECURE_NO_WARNINGS /nologo /D_HAS_EXCEPTIONS=0 /EHsc /W4 /wd4611 /Isrc test/test_type_traits.cpp /link /out:.\build\test_type_traits.exe
 
 del *.obj
-

--- a/scripts/run_tests.bat
+++ b/scripts/run_tests.bat
@@ -9,3 +9,4 @@ echo off
 .\build\test_doctest.exe
 .\build\test_color_off.exe
 .\build\test_color_on.exe
+.\build\test_type_traits.exe

--- a/src/jc_test.h
+++ b/src/jc_test.h
@@ -393,8 +393,10 @@ namespace jc {
     template <>          struct _jc_is_integral<unsigned int>       : public true_type {};
     template <>          struct _jc_is_integral<long>               : public true_type {};
     template <>          struct _jc_is_integral<unsigned long>      : public true_type {};
-    //not compat with c++98 template <>          struct _jc_is_integral<long long>          : public true_type {};
-    //not compat with c++98 template <>          struct _jc_is_integral<unsigned long long> : public true_type {};
+#if __cplusplus > 199711L
+    template <>          struct _jc_is_integral<long long>          : public true_type {};
+    template <>          struct _jc_is_integral<unsigned long long> : public true_type {};
+#endif
 
     template <class _Tp> struct is_integral : public _jc_is_integral<typename remove_cv<_Tp>::type> {};
 
@@ -474,6 +476,9 @@ namespace jc {
                                          !is_floating_point<_Tp>::value   &&
                                          !is_array<_Tp>::value            &&
                                          !is_pointer<_Tp>::value          &&
+#if __cplusplus > 199711L
+                                         !__is_nullptr_t<_Tp>::value      &&
+#endif
                                          !is_reference<_Tp>::value        &&
                                          !is_member_pointer<_Tp>::value   &&
                                          !is_union<_Tp>::value            &&

--- a/test/test_type_traits.cpp
+++ b/test/test_type_traits.cpp
@@ -1,0 +1,58 @@
+#define JC_TEST_USE_COLORS 1
+#define JC_TEST_USE_DEFAULT_MAIN
+#include <jc_test.h>
+
+#if __cplusplus > 199711L
+#include <type_traits>
+#endif
+
+typedef enum {
+    A,
+    B,
+    C
+} enum_t;
+
+typedef void *function_t(int, double, char *);
+
+TEST(TypesTraits, Integral_t)
+{
+#if __cplusplus > 199711L
+    ASSERT_EQ(true, jc::is_integral<long long>::value);
+    ASSERT_EQ(std::is_integral<long long>::value, jc::is_integral<long long>::value);
+
+    ASSERT_EQ(true, jc::is_integral<unsigned long long>::value);
+    ASSERT_EQ(std::is_integral<unsigned long long>::value, jc::is_integral<unsigned long long>::value);
+#endif
+}
+
+TEST(TypesTraits, Ptr_t)
+{
+    ASSERT_EQ(false, jc::is_pointer<function_t>::value);
+#if __cplusplus > 199711L
+    ASSERT_EQ(std::is_pointer<function_t>::value, jc::is_pointer<function_t>::value);
+#endif
+
+    ASSERT_EQ(true, jc::is_pointer<void *>::value);
+#if __cplusplus > 199711L
+    ASSERT_EQ(std::is_pointer<void *>::value, jc::is_pointer<void *>::value);
+#endif
+}
+
+TEST(TypesTraits, Function_t)
+{
+    ASSERT_EQ(true, jc::is_function<function_t>::value);
+#if __cplusplus > 199711L
+    ASSERT_EQ(std::is_function<function_t>::value, jc::is_function<function_t>::value);
+#endif
+}
+
+TEST(TypesTraits, Enum_t)
+{
+    ASSERT_EQ(true, jc::is_enum<enum_t>::value);
+#if __cplusplus > 199711L
+    ASSERT_EQ(std::is_enum<enum_t>::value, jc::is_enum<enum_t>::value);
+    ASSERT_EQ(std::is_enum<std::nullptr_t>::value, jc::is_enum<std::nullptr_t>::value);
+#endif
+}
+
+//////////////////////////////////////////////


### PR DESCRIPTION
Fixed inconsistency between `jc::is_enum` and `std::is_enum` when checking `std::nullptr_t`.

Type traits is extremely diffcult to implement correctly. Maybe to use `<type_traits>` header directly when available is a good idea, but it conflicts with the goal of **No STL**.

More test cases are necessray to ensure correctness of type traits implemented in `namespace jc`.