### PR TITLE
Removed doctest support

### DIFF
--- a/hugo/content/api/features.md
+++ b/hugo/content/api/features.md
@@ -51,11 +51,11 @@ regarding compile time and runtime.
 | Feature vs Impl        | jc_test |  gtest  | greatest |  utest  | doctest |  catch2 | snow 2  |
 |-----------------------:|---------|---------|----------|---------|---------|---------|---------|
 | Header only            |   yes   |    no   |    yes   |   yes   |   yes   |   yes   |   yes   |
-| Version                |  C++98  |  C++11  |    C89   |   C89   |  C++11  |  C++11  | c99/c11 |
+| Version                |  C++11  |  C++11  |    C89   |   C89   |  C++11  |  C++11  | c99/c11 |
 | -Wall                  |   yes   |   yes   |    no    |   no    |   yes   |   yes   |   yes   |
 | -Weverything           |   yes   |    no   |    no    |   no    |   yes   |    no   |    no   |
 | -pedantic              |   yes*  |    no   |    no    |   no    |   yes   |    no   |    no   |
-| Lines of Code**        |  ~1100  |  10000+ |   <1000  |  <400   |  4000+  |  11000+ |  ~1100  |
+| Lines of Code**        |  ~1300  |  10000+ |   <1000  |  <400   |  4000+  |  11000+ |  ~1100  |
 | Size of program***     |  27292  |  414608 |   19228  |  18280  |  146348 |  829572 |  23144  |
 | Compile time***        |  217ms  |  600ms  |   141ms  |   86ms  |  1890ms | 10662ms |  216ms  |
 | Run time***            |    3ms  |    3ms  |    6ms   |    5ms  |    3ms  |   4ms   |   3ms   |

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -98,7 +98,6 @@ time compile_test expect -Wno-sign-compare
 time compile_test death
 time compile_test empty
 time compile_test array
-time compile_test_with_main doctest
 time compile_test_with_main color_on
 time compile_test_with_main color_off
 

--- a/scripts/compile_cl.bat
+++ b/scripts/compile_cl.bat
@@ -18,7 +18,6 @@ set FLAGS=/O2 /D_CRT_SECURE_NO_WARNINGS /nologo /D_HAS_EXCEPTIONS=0 /EHsc /W4 /w
 %TIMEIT% cl.exe %FLAGS% test\test_death.cpp test\main.cpp /link /out:.\build\test_death.exe
 %TIMEIT% cl.exe %FLAGS% test\test_empty.cpp test\main.cpp /link /out:.\build\test_empty.exe
 %TIMEIT% cl.exe %FLAGS% test\test_array.cpp test\main.cpp /link /out:.\build\test_array.exe
-%TIMEIT% cl.exe %FLAGS% test\test_doctest.cpp /link /out:.\build\test_doctest.exe
 %TIMEIT% cl.exe %FLAGS% test\test_color_off.cpp /link /out:.\build\test_color_off.exe
 %TIMEIT% cl.exe %FLAGS% test\test_color_on.cpp /link /out:.\build\test_color_on.exe
 

--- a/src/jc_test.h
+++ b/src/jc_test.h
@@ -11,6 +11,7 @@
  * HISTORY:
  *      0.9     2022-12-22  Fixed proper printout for pointer values
  *                          Minimum version is now C++11 due to usage of <type_traits>
+ *                          Removed doctest support
  *      0.8     2021-04-03  Added fflush to logging to prevent test output becoming out of order
  *      0.7     2021-02-07  Fixed null pointer warning on C++0x and above
  *                          Test filtering now works on parameterized tests
@@ -598,10 +599,6 @@ struct jc_test_cmp_eq_helper {
 
 #define SCOPED_TRACE(_MSG)  // nop
 
-// doctest compatible
-#define CHECK( VALUE ) ASSERT_TRUE(VALUE)
-#define CHECK_EQ( A, B ) ASSERT_EQ(A, B)
-
 template<typename T>
 struct jc_test_value_iterator {
     virtual ~jc_test_value_iterator();
@@ -874,8 +871,6 @@ template<template <typename T> class BaseClass> struct jc_test_template_sel {
                 jc_test_template_sel<JC_TEST_MAKE_CLASS_NAME(testfixture,testfn)>,                          \
                 JC_TEST_MAKE_NAME2(testfixture,Types)>::register_test(#testfixture, #testfn, 0);            \
     template<typename T> void JC_TEST_MAKE_CLASS_NAME(testfixture,testfn)<T>::TestBody()
-
-#define TEST_CASE(name) TEST3(JC_TEST_MAKE_NAME2(_JC_TEST_ANON, __LINE__), name, "")
 
 #if !defined(_MSC_VER)
 #pragma GCC diagnostic pop

--- a/test/test_doctest.cpp
+++ b/test/test_doctest.cpp
@@ -1,7 +1,0 @@
-#define JC_TEST_USE_DEFAULT_MAIN
-#include <jc_test.h>
-
-TEST_CASE(multiply) {
-  CHECK_EQ(4, 2*2);
-  CHECK(4 == 2*2);
-}


### PR DESCRIPTION
Closes https://github.com/JCash/jctest/issues/18

Since the support was never implemented fully, I'll remove it.
The users can define their own macros etc as a workaround.